### PR TITLE
feat: 메뉴별 옵션 (옵션뷰에 매장정보, 메뉴리스트에 매장정보 추가해야함)

### DIFF
--- a/src/main/java/shop/project/pathorderserver/menu/MenuRepository.java
+++ b/src/main/java/shop/project/pathorderserver/menu/MenuRepository.java
@@ -11,4 +11,8 @@ public interface MenuRepository extends JpaRepository<Menu, Integer> {
     // 매장별 메뉴 리스트
     @Query("select m from Menu m where m.store.id = :storeId")
     Optional<List<Menu>> findAllMenuByStoreId(@Param("storeId") Integer storeId);
+
+    // 메뉴별 옵션
+    @Query("select o from Option o join fetch o.menu m where o.menu.id = :menuId")
+    Optional<List<Option>> findOptionByMenuId(@Param("menuId") Integer menuId);
 }

--- a/src/main/java/shop/project/pathorderserver/menu/MenuResponse.java
+++ b/src/main/java/shop/project/pathorderserver/menu/MenuResponse.java
@@ -1,6 +1,9 @@
 package shop.project.pathorderserver.menu;
 
+import jakarta.persistence.*;
 import lombok.Data;
+
+import java.util.List;
 
 public class MenuResponse {
 
@@ -17,6 +20,24 @@ public class MenuResponse {
             this.description = menu.getDescription();
             this.price = menu.getPrice();
             this.imgSrc = menu.getImgSrc();
+        }
+    }
+
+    // 메뉴별 옵션 DTO
+    @Data
+    public static class OptionDTO {
+        // 메뉴
+        // 옵션
+        private int optionId;
+        private String optionName;
+        private int optionPrice;
+        private boolean isRequired;
+
+        public OptionDTO(Option option) {
+            this.optionId = option.getId();
+            this.optionName = option.getName();
+            this.optionPrice = option.getPrice();
+            this.isRequired = option.isRequired();
         }
     }
 }

--- a/src/main/java/shop/project/pathorderserver/menu/MenuService.java
+++ b/src/main/java/shop/project/pathorderserver/menu/MenuService.java
@@ -15,4 +15,10 @@ public class MenuService {
         List<Menu> menuList = menuRepository.findAllMenuByStoreId(storeId).get(); // TODO: orElseThrow
         return menuList.stream().map(menu -> new MenuResponse.StoreMenuDTO(menu)).toList();
     }
+
+    // 메뉴별 옵션 리스트
+    public List<MenuResponse.OptionDTO> getOption(int menuId) {
+        List<Option> optionList = menuRepository.findOptionByMenuId(menuId).get(); // TODO: orElseThrow
+        return optionList.stream().map(option -> new MenuResponse.OptionDTO(option)).toList();
+    }
 }

--- a/src/main/java/shop/project/pathorderserver/order/OrderController.java
+++ b/src/main/java/shop/project/pathorderserver/order/OrderController.java
@@ -26,4 +26,13 @@ public class OrderController {
 
         return ResponseEntity.ok(new ApiUtil(menuList));
     }
+
+    // 메뉴별 옵션
+    // menuId가 storeId를 가지고 있는데 storeId가 필요한가?
+    @GetMapping("/api/stores/{storeId}/menus/{menuId}/options")
+    private ResponseEntity<?> option(@PathVariable int menuId) {
+        List<MenuResponse.OptionDTO> optionList = menuService.getOption(menuId);
+
+        return ResponseEntity.ok(new ApiUtil(optionList));
+    }
 }

--- a/src/test/java/shop/project/pathorderserver/menu/MenuRepositoryTest.java
+++ b/src/test/java/shop/project/pathorderserver/menu/MenuRepositoryTest.java
@@ -25,4 +25,14 @@ class MenuRepositoryTest {
         // then
         Assertions.assertThat(menuList.get().size()).isEqualTo(5);
     }
+
+    @Test
+    void findOptionByMenuId_test() {
+        // given
+        Integer menuId = 1;
+        // when
+        Optional<List<Option>> optionOP = menuRepository.findOptionByMenuId(menuId);
+        // then
+        Assertions.assertThat(optionOP.get().size()).isEqualTo(6);
+    }
 }


### PR DESCRIPTION
# 변경사항
- MenuRepository
```
// 메뉴별 옵션
@Query("select o from Option o join fetch o.menu m where o.menu.id = :menuId")
Optional<List<Option>> findOptionByMenuId(@Param("menuId") Integer menuId);
```
- MenuResponse
```
// 메뉴별 옵션 DTO
@Data
public static class OptionDTO {
    // 메뉴
    // 옵션
    private int optionId;
    private String optionName;
    private int optionPrice;
    private boolean isRequired;

    public OptionDTO(Option option) {
        this.optionId = option.getId();
        this.optionName = option.getName();
        this.optionPrice = option.getPrice();
        this.isRequired = option.isRequired();
    }
}
```
- MenuService
```
// 메뉴별 옵션 리스트
public List<MenuResponse.OptionDTO> getOption(int menuId) {
    List<Option> optionList = menuRepository.findOptionByMenuId(menuId).get(); // TODO: orElseThrow
    return optionList.stream().map(option -> new MenuResponse.OptionDTO(option)).toList();
}
```
- OrderController
```
// 메뉴별 옵션
// menuId가 storeId를 가지고 있는데 storeId가 필요한가?
@GetMapping("/api/stores/{storeId}/menus/{menuId}/options")
private ResponseEntity<?> option(@PathVariable int menuId) {
    List<MenuResponse.OptionDTO> optionList = menuService.getOption(menuId);

    return ResponseEntity.ok(new ApiUtil(optionList));
}
```