### PR TITLE
feat: Web 서버 예외처리 (fix: 매장 수정하기 폼 매핑)

### DIFF
--- a/src/main/java/shop/project/pathorderserver/_core/config/WebMvcConfig.java
+++ b/src/main/java/shop/project/pathorderserver/_core/config/WebMvcConfig.java
@@ -6,6 +6,7 @@ import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.resource.PathResourceResolver;
 import shop.project.pathorderserver._core.interceptor.LoginInterceptor;
+import shop.project.pathorderserver._core.interceptor.SSRLoginInterceptor;
 
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {
@@ -24,5 +25,8 @@ public class WebMvcConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new LoginInterceptor())
                 .addPathPatterns("/api/**");
+        registry.addInterceptor(new SSRLoginInterceptor())
+                .addPathPatterns("/stores/**")
+                .excludePathPatterns("/stores/login", "/stores/login-form", "stores/join", "/stores/join-form");
     }
 }

--- a/src/main/java/shop/project/pathorderserver/_core/errors/MyExceptionHandler.java
+++ b/src/main/java/shop/project/pathorderserver/_core/errors/MyExceptionHandler.java
@@ -29,7 +29,6 @@ public class MyExceptionHandler {
     }
     
     @ExceptionHandler(Exception404.class)
-
     public ResponseEntity<?> ex404(Exception404 e){
         ApiUtil<?> apiUtil = new ApiUtil<>(404, e.getMessage());
         return new ResponseEntity<>(apiUtil, HttpStatus.NOT_FOUND);

--- a/src/main/java/shop/project/pathorderserver/_core/errors/SSRExceptionHandler.java
+++ b/src/main/java/shop/project/pathorderserver/_core/errors/SSRExceptionHandler.java
@@ -1,0 +1,50 @@
+package shop.project.pathorderserver._core.errors;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import shop.project.pathorderserver._core.errors.exception.*;
+
+@ControllerAdvice //runtimeException 이 터지만 해당 파일로 오류가 모인다.
+public class SSRExceptionHandler {
+
+    @ExceptionHandler(Exception400.class)
+    public String ex400(Exception400 e, HttpServletRequest request) {
+        request.setAttribute("msg", e.getMessage());
+        request.setAttribute("status", 400);
+
+        return "error";
+    }
+
+    @ExceptionHandler(Exception401.class)
+    public String ex401(Exception401 e, HttpServletRequest request) {
+        request.setAttribute("msg", e.getMessage());
+        request.setAttribute("status", 401);
+
+        return "error";
+    }
+
+    @ExceptionHandler(Exception403.class)
+    public String ex403(RuntimeException e, HttpServletRequest request) {
+        request.setAttribute("msg", e.getMessage());
+        request.setAttribute("status", 403);
+
+        return "error";
+    }
+
+    @ExceptionHandler(Exception404.class)
+    public String ex404(RuntimeException e, HttpServletRequest request) {
+        request.setAttribute("msg", e.getMessage());
+        request.setAttribute("status", 404);
+
+        return "error";
+    }
+
+    @ExceptionHandler(Exception500.class)
+    public String ex500(RuntimeException e, HttpServletRequest request) {
+        request.setAttribute("msg", e.getMessage());
+        request.setAttribute("status", 500);
+
+        return "error";
+    }
+}

--- a/src/main/java/shop/project/pathorderserver/_core/errors/SSRExceptionHandler.java
+++ b/src/main/java/shop/project/pathorderserver/_core/errors/SSRExceptionHandler.java
@@ -3,7 +3,7 @@ package shop.project.pathorderserver._core.errors;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import shop.project.pathorderserver._core.errors.exception.*;
+import shop.project.pathorderserver._core.errors.exceptionssr.*;
 
 @ControllerAdvice //runtimeException 이 터지만 해당 파일로 오류가 모인다.
 public class SSRExceptionHandler {

--- a/src/main/java/shop/project/pathorderserver/_core/errors/exceptionssr/Exception400.java
+++ b/src/main/java/shop/project/pathorderserver/_core/errors/exceptionssr/Exception400.java
@@ -1,0 +1,8 @@
+package shop.project.pathorderserver._core.errors.exceptionssr;
+
+public class Exception400 extends RuntimeException {
+
+    public Exception400(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/shop/project/pathorderserver/_core/errors/exceptionssr/Exception401.java
+++ b/src/main/java/shop/project/pathorderserver/_core/errors/exceptionssr/Exception401.java
@@ -1,0 +1,8 @@
+package shop.project.pathorderserver._core.errors.exceptionssr;
+
+public class Exception401 extends RuntimeException {
+
+    public Exception401(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/shop/project/pathorderserver/_core/errors/exceptionssr/Exception403.java
+++ b/src/main/java/shop/project/pathorderserver/_core/errors/exceptionssr/Exception403.java
@@ -1,0 +1,8 @@
+package shop.project.pathorderserver._core.errors.exceptionssr;
+
+public class Exception403 extends RuntimeException {
+
+    public Exception403(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/shop/project/pathorderserver/_core/errors/exceptionssr/Exception404.java
+++ b/src/main/java/shop/project/pathorderserver/_core/errors/exceptionssr/Exception404.java
@@ -1,0 +1,7 @@
+package shop.project.pathorderserver._core.errors.exceptionssr;
+
+public class Exception404 extends RuntimeException {
+    public Exception404(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/shop/project/pathorderserver/_core/errors/exceptionssr/Exception500.java
+++ b/src/main/java/shop/project/pathorderserver/_core/errors/exceptionssr/Exception500.java
@@ -1,0 +1,8 @@
+package shop.project.pathorderserver._core.errors.exceptionssr;
+
+public class Exception500 extends RuntimeException {
+
+    public Exception500(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/shop/project/pathorderserver/_core/interceptor/SSRLoginInterceptor.java
+++ b/src/main/java/shop/project/pathorderserver/_core/interceptor/SSRLoginInterceptor.java
@@ -1,0 +1,21 @@
+package shop.project.pathorderserver._core.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.web.servlet.HandlerInterceptor;
+import shop.project.pathorderserver._core.errors.exception.Exception401;
+import shop.project.pathorderserver.store.SessionStore;
+
+public class SSRLoginInterceptor implements HandlerInterceptor {
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        HttpSession session = request.getSession();
+
+        SessionStore sessionStore = (SessionStore) session.getAttribute("sessionStore");
+        if (sessionStore == null) {
+            throw new Exception401("로그인 하셔야 해요");
+        }
+        return true;
+    }
+}

--- a/src/main/java/shop/project/pathorderserver/_core/interceptor/SSRLoginInterceptor.java
+++ b/src/main/java/shop/project/pathorderserver/_core/interceptor/SSRLoginInterceptor.java
@@ -4,7 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.web.servlet.HandlerInterceptor;
-import shop.project.pathorderserver._core.errors.exception.Exception401;
+import shop.project.pathorderserver._core.errors.exceptionssr.Exception401;
 import shop.project.pathorderserver.store.SessionStore;
 
 public class SSRLoginInterceptor implements HandlerInterceptor {

--- a/src/main/resources/templates/error.mustache
+++ b/src/main/resources/templates/error.mustache
@@ -1,0 +1,23 @@
+<div style="display: flex; justify-content: center">
+    <div class="card" style="width: 400px; margin-top: 5%; margin-bottom: 10%">
+        <div class="card-header" style="text-align: center">
+            <h2>에러</h2>
+        </div>
+        <div class="card-body" style="text-align: center">
+            <div class="mb-5">
+                <h3>메세지</h3>
+                <hr>
+                {{#msg}}
+                    <div>{{msg}}</div>
+                {{/msg}}
+            </div>
+            <div class="mb-5">
+                <h3>상태코드</h3>
+                <hr>
+                {{#status}}
+                    <div>{{status}}</div>
+                {{/status}}
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/main/resources/templates/menus-create-form.mustache
+++ b/src/main/resources/templates/menus-create-form.mustache
@@ -7,7 +7,7 @@
                 <h1 class="modal-title fs-5" id="addMenuModalLabel">메뉴 추가</h1>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <form action="/stores/1/menus" method="post" enctype="multipart/form-data">
+            <form action="/stores/{{sessionStore.id}}/menus" method="post" enctype="multipart/form-data">
                 <div class="modal-body"> <!--TODO: 유효성 검사-->
                     <div class="mb-3">
                         <label for="category" class="col-form-label">카테고리</label>

--- a/src/main/resources/templates/orders.mustache
+++ b/src/main/resources/templates/orders.mustache
@@ -52,7 +52,7 @@
                 <!-- TODO: 모델에 데이터 담아서 머스태치 수정하기 /stores/{storeId}/orders/{orderId}/update -->
                 {{#orders.pendingOrderList}}
                     <div class="card mb-4" style="font-size: 12px;width: 240px; padding: 0;">
-                        <form action="/stores/1/orders/{{orderId}}/update" method="post">
+                        <form action="/stores/{{sessionStore.id}}/orders/{{orderId}}/update" method="post">
                             <input type="hidden" name="status" value="{{status}}">
                             <div style="padding: 10px;">
                                 <div class="d-flex justify-content-start" style="margin-bottom: 10px;">
@@ -102,7 +102,7 @@
                 {{/orders.pendingOrderList}}
                 {{#orders.preparingOrderList}}
                     <div class="card mb-4" style="font-size: 12px;width: 240px; padding: 0;">
-                        <form action="/stores/1/orders/{{orderId}}/update" method="post">
+                        <form action="/stores/{{sessionStore.id}}/orders/{{orderId}}/update" method="post">
                             <input type="hidden" name="status" value="{{status}}">
                             <div style="padding: 10px;">
                                 <div class="d-flex justify-content-start" style="margin-bottom: 10px;">
@@ -152,7 +152,7 @@
                 {{/orders.preparingOrderList}}
                 {{#orders.preparedOrderList}}
                     <div class="card mb-4" style="font-size: 12px;width: 240px; padding: 0;">
-                        <form action="/stores/1/orders/{{orderId}}/update" method="post">
+                        <form action="/stores/{{sessionStore.id}}/orders/{{orderId}}/update" method="post">
                             <input type="hidden" name="status" value="{{status}}">
                             <div style="padding: 10px;">
                                 <div class="d-flex justify-content-start" style="margin-bottom: 10px;">

--- a/src/main/resources/templates/store-update-form.mustache
+++ b/src/main/resources/templates/store-update-form.mustache
@@ -92,48 +92,48 @@
                                     <div class="input-group mb-3">
                                                 <span
                                                         class="input-group-text init_color justify-content-center hs_span_size hs_span">상호명</span>
-                                        <input type="text" class="form-control" value="store.name" name="name"
+                                        <input type="text" class="form-control" value="{{storeDetail.name}}" name="name"
                                                id="" required>
                                     </div>
                                     <div class="input-group mb-3">
                                                 <span
                                                         class="input-group-text init_color justify-content-center hs_span_size hs_span">매장
                                                     전화번호</span>
-                                        <input type="text" class="form-control" value="store.tel" name="text"
+                                        <input type="text" class="form-control" value="{{storeDetail.tel}}" name="text"
                                                id="" required>
                                     </div>
                                     <div class="input-group mb-3">
                                                 <span
                                                         class="input-group-text init_color justify-content-center hs_span_size hs_span">매장소개</span>
                                         <input type="text" class="form-control" maxlength="11"
-                                               value="store.intro" name="text" id="" required>
+                                               value="{{storeDetail.intro}}" name="text" id="" required>
                                     </div>
                                     <div class="input-group mb-3">
                                                 <span
                                                         class="input-group-text init_color justify-content-center hs_span_size hs_span">개점시간</span>
-                                        <input type="time" class="form-control" value="store.openingTime"
+                                        <input type="time" class="form-control" value="{{storeDetail.openingTime}}"
                                                name="address" id="" required>
                                     </div>
                                     <div class="input-group mb-3">
                                                 <span
                                                         class="input-group-text init_color justify-content-center hs_span_size hs_span">폐점시간</span>
-                                        <input type="time" class="form-control" value="store.closingTime"
+                                        <input type="time" class="form-control" value="{{storeDetail.closingTime}}"
                                                name="email" id="" required>
                                     </div>
                                     <div class="input-group mb-3">
                                                 <span
                                                         class="input-group-text init_color justify-content-center hs_span_size hs_span">휴무일</span>
-                                        <input type="date" class="form-control" value="store.closedDay"
+<!--                                        TODO: 타입을 date로 해야 하나?-->
+                                        <input type="date" class="form-control" value="{{storeDetail.closedDay}}"
                                                name="birth" id="" required>
                                     </div>
                                     <div class="input-group mb-3">
                                                 <span
                                                         class="input-group-text init_color justify-content-center hs_span_size hs_span">매장
                                                     주소</span>
-                                        <input type="text" class="form-control" value="store.adress"
+                                        <input type="text" class="form-control" value="{{storeDetail.address}}"
                                                name="email" id="" required>
                                     </div>
-                                    <div>지도</div>
                                     <div class="mt-5">
                                         <h4 class="border-bottom pb-4">사업자 정보</h4>
                                     </div>
@@ -141,32 +141,33 @@
                                                 <span
                                                         class="input-group-text init_color justify-content-center hs_span_size hs_span">사업주
                                                     이름</span>
-                                        <input type="text" class="form-control" value="store.ownerName"
+                                        <input type="text" class="form-control" value="{{storeDetail.ownerName}}"
                                                name="name" id="" required>
                                     </div>
                                     <div class="input-group mb-3">
                                                 <span
                                                         class="input-group-text init_color justify-content-center hs_span_size hs_span">사업주
                                                     연락처</span>
-                                        <input type="tel" class="form-control" value="store.ownerTel"
+                                        <input type="tel" class="form-control" value="{{storeDetail.ownerTel}}"
                                                name="ownerTel" id="" required>
                                     </div>
                                     <div class="input-group mb-3">
                                                 <span
                                                         class="input-group-text init_color justify-content-center hs_span_size hs_span">사업주
                                                     이메일</span>
-                                        <input type="email" class="form-control" value="store.ownerEmail"
+                                        <input type="email" class="form-control" value="{{storeDetail.ownerEmail}}"
                                                name="ownerEmail" id="" required>
                                     </div>
                                     <div class="input-group mb-3">
                                                 <span
                                                         class="input-group-text init_color justify-content-center hs_span_size hs_span">사업자
                                                     번호</span>
-                                        <input type="text" class="form-control" value="store.bizNum"
+                                        <input type="text" class="form-control" value="{{storeDetail.bizNum}}"
                                                name="bizNum" id="" required>
                                     </div>
                                     <div class="mt-5">
                                         <h4 class="border-bottom pb-4">비밀번호 수정</h4>
+<!--                                        TODO: 비밀번호 수정 추후에 다시-->
                                     </div>
                                     <br>
                                     <div class="company-password">


### PR DESCRIPTION
# 업데이트
- url 1로 매핑돼있는 것들 sessionStore.id로 변경
- 매장 수정하기 들어가면 데이터 매핑 안 돼있는 것들 mustache에서 수정

- 로그인 하기 전에 url로 다른 페이지 들어갈 때 막아주는 인터셉터와 에러페이지를 만들었는데 api가 아닌 모든 stores로 시작하는 페이지도 view를 응답하지 않고 json으로 응답하는 문제가 있었다.
  - 모든 핸들러와 인터셉터에서 import 돼있는 것들이 같은 곳을 가르키고 있던 것이 문제.
    ![image](https://github.com/9oj0e/pathorder_server/assets/153582301/c91bf514-b20b-4bb6-8d83-f4270965cd06)
   - 나누어서 각자 필요한 것들을 import 해주니까 해결됨.